### PR TITLE
Support esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "purifree-ts",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Point-free Functional programming library for TypeScript",
-  "main": "index.js",
-  "types": "index.d.ts",
   "repository": "https://github.com/nythrox/purifree.git",
   "author": "nythrox <jasonsantiagobutler@gmail.com>",
   "license": "MIT",
@@ -25,6 +23,30 @@
       "js"
     ],
     "collectCoverage": true
+  },
+  "main": "index.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./es/index.d.ts",
+        "default": "./es/index.js"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
+    },
+    "./*": {
+      "import": {
+        "types": "./es/*.d.ts",
+        "default": "./es/*.js"
+      },
+      "require": {
+        "types": "./*.d.ts",
+        "default": "./*.js"
+      }
+    }
   },
   "devDependencies": {
     "@types/jest": "27.4.1",


### PR DESCRIPTION
This ensures native support for ES modules and therefore Deno and other JS runtimes.
To use with deno after this do:
```ts
import purifreeTs from 'https://cdn.skypack.dev/purifree-ts?dts';
```